### PR TITLE
Mismatched italicised parentheses fixed

### DIFF
--- a/books/Ps.xml
+++ b/books/Ps.xml
@@ -3454,7 +3454,7 @@
             Seigneur notre Dieu est saint. </ab>
     </div>
     <div type="chapter" n="99">
-        <ab n="1"><hi rend="italics">Psaume pour la (de) louange </hi>(ou<hi rend="italics"> d’actions de grâces).</hi> </ab>
+        <ab n="1"><hi rend="italics">Psaume pour la (de) louange </hi>(ou <hi rend="italics">d’actions de grâces.</hi>) </ab>
         <ab n="2">Acclamez Dieu, toute la terre ; servez le Seigneur avec joie. Entrez en sa
             présence avec allégresse (exultation). </ab>
         <ab n="3">Sachez que c’est le Seigneur qui est Dieu ; c’est lui(-même) qui nous a faits,
@@ -3465,7 +3465,7 @@
             vérité demeure de génération en génération. </ab>
     </div>
     <div type="chapter" n="100">
-        <ab n="1"><hi rend="italics">Psaume à David </hi>(ou<hi rend="italics"> de David lui-même).</hi> Je chanterai, Seigneur,
+        <ab n="1"><hi rend="italics">Psaume à David </hi>(ou <hi rend="italics">de David lui-même.</hi>) Je chanterai, Seigneur,
             devant vous votre miséricorde et votre justice. Je les chanterai au son des instruments
             (sur le psaltérion), </ab>
         <ab n="2">et je m’appliquerai à connaître la (comprendre une) voie sans tache. Quand
@@ -4888,7 +4888,7 @@
             pierre. </ab>
     </div>
     <div type="chapter" n="137">
-        <ab n="1"><hi rend="italics">De (A) David </hi>(ou<hi rend="italics"> de David lui-même).</hi> Je vous célébrerai
+        <ab n="1"><hi rend="italics">De (A) David </hi>(ou <hi rend="italics">de David lui-même.</hi>) Je vous célébrerai
             (glorifierai), Seigneur, de tout mon cœur, parce que vous avez écouté les paroles de ma
             bouche. Je vous chanterai des hymnes en présence des anges ; </ab>
         <ab n="2">j’adorerai dans (en me tournant vers) votre saint temple, et je célébrerai
@@ -5099,7 +5099,7 @@
             (mais plutôt bien)heureux le peuple qui a le Seigneur pour son Dieu. </ab>
     </div>
     <div type="chapter" n="144">
-        <ab n="1"><hi rend="italics">Louange de (à) David </hi>(ou <hi rend="italics">de David lui-même).</hi> Je vous exalterai,
+        <ab n="1"><hi rend="italics">Louange de (à) David </hi>(ou <hi rend="italics">de David lui-même.</hi>) Je vous exalterai,
             ô (mon) Dieu mon roi, et je bénirai votre nom à jamais et dans les siècles des siècles. </ab>
         <ab n="2">Chaque jour je vous bénirai, et je louerai votre nom à jamais, et dans les
             siècles des siècles. </ab>


### PR DESCRIPTION
See comments under https://github.com/MarjorieBurghart/VulgateGlaire/issues/19

Also moved a space to before the start of italics markup in 3 of these 4 places.

@MarjorieBurghart - please review. _Thanks_.